### PR TITLE
no more act() warnings

### DIFF
--- a/src/components/__tests__/RemotePizza_di.spec.js
+++ b/src/components/__tests__/RemotePizza_di.spec.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import waitForExpect from 'wait-for-expect';
 import RemotePizza from '../RemotePizza';
+import {act} from 'react-dom/test-utils'
 
 const ingredients = ['bacon', 'tomato', 'mozzarella', 'pineapples'];
 
@@ -17,7 +18,9 @@ test('download ingredients from internets', async () => {
     });
   const wrapper = mount(<RemotePizza fetchIngredients={fetchIngredients} />);
 
-  wrapper.find({ children: 'Cook' }).simulate('click');
+  await act(async () => {
+    wrapper.find({ children: 'Cook' }).simulate('click');  
+  })
 
   await waitForExpect(() => {
     wrapper.update();

--- a/src/components/__tests__/RemotePizza_fetchmock.spec.js
+++ b/src/components/__tests__/RemotePizza_fetchmock.spec.js
@@ -6,6 +6,7 @@ import { mount } from 'enzyme';
 import fetchMock from 'fetch-mock';
 import waitForExpect from 'wait-for-expect';
 import RemotePizza from '../RemotePizza';
+import {act} from 'react-dom/test-utils'
 
 const ingredients = ['bacon', 'tomato', 'mozzarella', 'pineapples'];
 
@@ -20,9 +21,12 @@ test('download ingredients from internets', async () => {
     body: { args: { ingredients } },
   });
 
-  const wrapper = mount(<RemotePizza />);
 
-  wrapper.find({ children: 'Cook' }).simulate('click');
+  const wrapper = mount(<RemotePizza />);
+  await act(async () => {
+    wrapper.find({ children: 'Cook' }).simulate('click');  
+  })
+  
 
   await waitForExpect(() => {
     wrapper.update();

--- a/src/components/__tests__/RemotePizza_jestmock.spec.js
+++ b/src/components/__tests__/RemotePizza_jestmock.spec.js
@@ -6,6 +6,7 @@ import { mount } from 'enzyme';
 import waitForExpect from 'wait-for-expect';
 import RemotePizza from '../RemotePizza';
 import { fetchIngredients } from '../../services';
+import {act} from 'react-dom/test-utils'
 
 jest.mock('../../services');
 
@@ -22,7 +23,9 @@ test('download ingredients from internets', async () => {
 
   const wrapper = mount(<RemotePizza />);
 
-  wrapper.find({ children: 'Cook' }).simulate('click');
+  await act(async () => {
+    wrapper.find({ children: 'Cook' }).simulate('click');  
+  })
 
   await waitForExpect(() => {
     wrapper.update();

--- a/src/components/__tests__/RemotePizza_nock.spec.js
+++ b/src/components/__tests__/RemotePizza_nock.spec.js
@@ -6,6 +6,7 @@ import { mount } from 'enzyme';
 import nock from 'nock';
 import waitForExpect from 'wait-for-expect';
 import RemotePizza from '../RemotePizza';
+import {act} from 'react-dom/test-utils'
 
 const ingredients = ['bacon', 'tomato', 'mozzarella', 'pineapples'];
 
@@ -23,13 +24,17 @@ test('download ingredients from internets', async () => {
 
   const wrapper = mount(<RemotePizza />);
 
-  wrapper.find({ children: 'Cook' }).simulate('click');
+  await act(async () => {
+    wrapper.find({ children: 'Cook' }).simulate('click');  
+  })
 
-  await waitForExpect(() => {
-    wrapper.update();
-    expect(scope.isDone()).toBe(true);
-    ingredients.forEach(ingredient => {
-      expect(wrapper.text()).toMatch(ingredient);
+  await act(async () => {
+    await waitForExpect(() => {
+      wrapper.update();
+      expect(scope.isDone()).toBe(true);
+      ingredients.forEach(ingredient => {
+        expect(wrapper.text()).toMatch(ingredient);
+      });
     });
-  });
+  })
 });


### PR DESCRIPTION
This PR actually uses async act to silence the warnings

(I'm not sure why the nock example needed an extra act(), I suppose it's mocking doesn't work like other mocking, and delays resolving it longer than it should)